### PR TITLE
Sync licenses and improve Asian-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ------------------------------------------------------------------------
-                     TRANSLATION ERROR RATE (TER) 0.8.0
+                     TRANSLATION ERROR RATE (TER) 0.9.0
 
         Matthew Snover
         Shuguang Wang
@@ -38,6 +38,7 @@ Currently, the following options are supported:
    -N normalization, optional, default is no.
    -s case sensitivity, optional, default is insensitive
    -P no punctuations, default is with punctuations.
+   -A Asian language support for -N and -P, optional, default is without.
    -r reference file path, required.
    -h hypothesis file path, required.
    -o output formats, optional, default are all formats.
@@ -70,7 +71,13 @@ Examples
    $ java -jar tercom.jar -N -s -b 10 -r <ref_file> -h <hyp_file> -n <output_prefix>
 ```
 
-3. Output only summary output.
+3. Same as above, but split most Chinese and Japanese text appearing in the output down to the character level.
+
+```bash
+   $ java -jar tercom.jar -N -A -s -b 10 -r <ref_file> -h <hyp_file> -n <output_prefix>
+```
+
+4. Output only summary output.
 
 ```bash
    $ java -jar tercom.jar -r <ref_file> -h <hyp_file> -o xml -n <output_prefix>

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project name="tercom" default="jar" basedir=".">
 
-  <property name="version" value="0.8.0" />
+  <property name="version" value="0.9.0" />
 
   <!-- Compile the Java code -->
   <target name="compile">

--- a/src/ter/Parameters.java
+++ b/src/ter/Parameters.java
@@ -13,6 +13,7 @@ public class Parameters {
   private boolean mt_normalized;
   private boolean case_on;
   private boolean no_punctuation;
+    private boolean asian_support;
   private List<String> out_formats;
   private String out_pfx;
   private Pattern opts_p;
@@ -27,7 +28,7 @@ public class Parameters {
     private double match_cost;
 
   public static enum OPTIONS {
-      NORMALIZE, CASEON, NOPUNCTUATION, REF, HYP, FORMATS, OUTPFX, BEAMWIDTH, REFLEN, TRANSSPAN, SHIFTDIST, DELETE_COST, INSERT_COST, SUBSTITUTE_COST, MATCH_COST, SHIFT_COST;
+      NORMALIZE, CASEON, NOPUNCTUATION, ASIANSUPPORT, REF, HYP, FORMATS, OUTPFX, BEAMWIDTH, REFLEN, TRANSSPAN, SHIFTDIST, DELETE_COST, INSERT_COST, SUBSTITUTE_COST, MATCH_COST, SHIFT_COST;
   }
 
   public Parameters() {
@@ -38,6 +39,7 @@ public class Parameters {
 	mt_normalized = false;
 	case_on = false;
 	no_punctuation = false;
+	asian_support = false;
 	opts_p = Pattern.compile("^\\s*-(\\S+)\\s*$");
 	beam_width = 20;
     span_pfx = "";
@@ -67,6 +69,9 @@ public class Parameters {
 		    break;
           case 'P':
 		    no_punctuation = true;
+		    break;
+	  case 'A':
+		    asian_support = true;
 		    break;
           case 'r':
 		    if(i == args.length -1 || args[i+1].charAt(0) == '-')
@@ -163,6 +168,7 @@ public class Parameters {
       paras.put(OPTIONS.NORMALIZE, mt_normalized);
       paras.put(OPTIONS.CASEON, case_on);
       paras.put(OPTIONS.NOPUNCTUATION, no_punctuation);
+      paras.put(OPTIONS.ASIANSUPPORT, asian_support);
       paras.put(OPTIONS.OUTPFX, out_pfx);
       paras.put(OPTIONS.REF, reffn);
       paras.put(OPTIONS.HYP, hypfn);
@@ -181,7 +187,7 @@ public class Parameters {
   }
 
   public static void usage() {
-	System.out.println("** Usage: java -jar tercom.jar [-N] [-s] [-P] -r ref -h hyp [-a alter_ref] [-b beam_width] [-S trans_span_prefix] [-o out_format -n out_pefix] [-d max_shift_distance] [-M match_cost] [-D delete_cost] [-B substitute_cost] [-I insert_cost] [-T shift_cost]");
+	System.out.println("** Usage: java -jar tercom.jar [-N] [-s] [-P] [-A] -r ref -h hyp [-a alter_ref] [-b beam_width] [-S trans_span_prefix] [-o out_format -n out_pefix] [-d max_shift_distance] [-M match_cost] [-D delete_cost] [-B substitute_cost] [-I insert_cost] [-T shift_cost]");
 	System.exit(1);
   }
 

--- a/src/ter/TER.java
+++ b/src/ter/TER.java
@@ -39,6 +39,8 @@ public class TER {
 	boolean caseon = (Boolean) val;
 	val = paras.get(Parameters.OPTIONS.NOPUNCTUATION);
 	boolean nopunct = (Boolean) val;
+	val = paras.get(Parameters.OPTIONS.ASIANSUPPORT);
+	boolean asiansupport = (Boolean) val;
 	val = paras.get(Parameters.OPTIONS.OUTPFX);
 	String out_pfx;
 	if(val != null)
@@ -140,6 +142,7 @@ public class TER {
 	calc.setNormalize(normalized);
 	calc.setCase(caseon);
 	calc.setPunct(nopunct);
+	calc.setAsian(asiansupport);
 	calc.setBeamWidth(beam_width);
 	calc.setShiftDist(shift_dist);
 

--- a/src/ter/core/Alignment.java
+++ b/src/ter/core/Alignment.java
@@ -2,35 +2,7 @@
 
 Copyright� 2006 by BBN Technologies and University of Maryland (UMD)
 
-BBN and UMD grant a nonexclusive, source code, royalty-free right to
-use this Software known as Translation Error Rate COMpute (the
-"Software") solely for research purposes. Provided, you must agree
-to abide by the license and terms stated herein. Title to the
-Software and its documentation and all applicable copyrights, trade
-secrets, patents and other intellectual rights in it are and remain
-with BBN and UMD and shall not be used, revealed, disclosed in
-marketing or advertisement or any other activity not explicitly
-permitted in writing.
-
-BBN and UMD make no representation about suitability of this
-Software for any purposes.  It is provided "AS IS" without express
-or implied warranties including (but not limited to) all implied
-warranties of merchantability or fitness for a particular purpose.
-In no event shall BBN or UMD be liable for any special, indirect or
-consequential damages whatsoever resulting from loss of use, data or
-profits, whether in an action of contract, negligence or other
-tortuous action, arising out of or in connection with the use or
-performance of this Software.
-
-Without limitation of the foregoing, user agrees to commit no act
-which, directly or indirectly, would violate any U.S. law,
-regulation, or treaty, or any other international treaty or
-agreement to which the United States adheres or with which the
-United States complies, relating to the export or re-export of any
-commodities, software, or technical data.  This Software is licensed
-to you on the condition that upon completion you will cease to use
-the Software and, on request of BBN and UMD, will destroy copies of
-the Software in your possession.                                                
+License: LGPL v. 2.1.  See LICENSE.txt.
 
 TERalignment.java v1
 Matthew Snover (snover@cs.umd.edu)                           

--- a/src/ter/core/CostFunction.java
+++ b/src/ter/core/CostFunction.java
@@ -2,35 +2,7 @@
                                                                 
 Copyright� 2006 by BBN Technologies and University of Maryland (UMD)
 
-BBN and UMD grant a nonexclusive, source code, royalty-free right to
-use this Software known as Translation Error Rate COMpute (the
-"Software") solely for research purposes. Provided, you must agree
-to abide by the license and terms stated herein. Title to the
-Software and its documentation and all applicable copyrights, trade
-secrets, patents and other intellectual rights in it are and remain
-with BBN and UMD and shall not be used, revealed, disclosed in
-marketing or advertisement or any other activity not explicitly
-permitted in writing.
-
-BBN and UMD make no representation about suitability of this
-Software for any purposes.  It is provided "AS IS" without express
-or implied warranties including (but not limited to) all implied
-warranties of merchantability or fitness for a particular purpose.
-In no event shall BBN or UMD be liable for any special, indirect or
-consequential damages whatsoever resulting from loss of use, data or
-profits, whether in an action of contract, negligence or other
-tortuous action, arising out of or in connection with the use or
-performance of this Software.
-
-Without limitation of the foregoing, user agrees to commit no act
-which, directly or indirectly, would violate any U.S. law,
-regulation, or treaty, or any other international treaty or
-agreement to which the United States adheres or with which the
-United States complies, relating to the export or re-export of any
-commodities, software, or technical data.  This Software is licensed
-to you on the condition that upon completion you will cease to use
-the Software and, on request of BBN and UMD, will destroy copies of
-the Software in your possession.                                                
+License: LGPL v. 2.1.  See LICENSE.txt.
 
 TERcost.java v1
 Matthew Snover (snover@cs.umd.edu)                           

--- a/src/ter/core/Normalizer.java
+++ b/src/ter/core/Normalizer.java
@@ -1,40 +1,69 @@
 package ter.core;
 
 public class Normalizer {
-	
-  public static String[] tokenize(String s, boolean normalized, boolean nopunct) {
-		/* tokenizes according to the mtevalv11 specs */
 
-		if(normalized) {
-	      // language-independent part:
-	      s = s.replaceAll("<skipped>", ""); // strip "skipped" tags
-	      s = s.replaceAll("-\n", ""); // strip end-of-line hyphenation and join lines
-	      s = s.replaceAll("\n", " "); // join lines
-	      s = s.replaceAll("&quot;", "\""); // convert SGML tag for quote to " 
-	      s = s.replaceAll("&amp;", "&"); // convert SGML tag for ampersand to &
-	      s = s.replaceAll("&lt;", "<"); // convert SGML tag for less-than to >
-	      s = s.replaceAll("&gt;", ">"); // convert SGML tag for greater-than to <
+    private static String asianPunct = "([\\x{3001}\\x{3002}\\x{3008}-\\x{3011}\\x{3014}-\\x{301f}\\x{ff61}-\\x{ff65}\\x{30fb}])";
+    private static String fullwidthPunct = "([\\x{ff0e}\\x{ff0c}\\x{ff1f}\\x{ff1a}\\x{ff1b}\\x{ff01}\\x{ff02}\\x{ff08}\\x{ff09}])";
+
+    public static String[] tokenize(String s, boolean normalized, boolean nopunct, boolean asianSupport) {
+
+	/* tokenizes according to the mtevalv11 specs, plus added material
+	   for handling languages written with CJK ideographs */
+
+	if(normalized) {
+	    // language-independent part:
+	    s = s.replaceAll("<skipped>", ""); // strip "skipped" tags
+	    s = s.replaceAll("-\n", ""); // strip end-of-line hyphenation and join lines
+	    s = s.replaceAll("\n", " "); // join lines
+	    s = s.replaceAll("&quot;", "\""); // convert SGML tag for quote to " 
+	    s = s.replaceAll("&amp;", "&"); // convert SGML tag for ampersand to &
+	    s = s.replaceAll("&lt;", "<"); // convert SGML tag for less-than to >
+	    s = s.replaceAll("&gt;", ">"); // convert SGML tag for greater-than to <
 		    
-	      // language-dependent part (assuming Western languages):
-	      s = " " + s + " ";
-	      s = s.replaceAll("([\\{-\\~\\[-\\` -\\&\\(-\\+\\:-\\@\\/])", " $1 ");   // tokenize punctuation
-	      s = s.replaceAll("'s ", " 's "); // handle possesives
-	      s = s.replaceAll("'s$", " 's"); // handle possesives     
-	      s = s.replaceAll("([^0-9])([\\.,])", "$1 $2 "); // tokenize period and comma unless preceded by a digit
-	      s = s.replaceAll("([\\.,])([^0-9])", " $1 $2"); // tokenize period and comma unless followed by a digit
-	      s = s.replaceAll("([0-9])(-)", "$1 $2 "); // tokenize dash when preceded by a digit
-	      s = s.replaceAll("\\s+"," "); // one space only between words
-	      s = s.replaceAll("^\\s+", "");  // no leading space
-	      s = s.replaceAll("\\s+$", "");  // no trailing space
-		}
-		if(nopunct) s = Normalizer.removePunctuation(s);
-		return s.split("\\s+");
-	  }
+	    // language-dependent part (assuming Western languages):
+	    s = " " + s + " ";
+	    s = s.replaceAll("([\\{-\\~\\[-\\` -\\&\\(-\\+\\:-\\@\\/])", " $1 ");   // tokenize punctuation
+	    s = s.replaceAll("'s ", " 's "); // handle possesives
+	    s = s.replaceAll("'s$", " 's"); // handle possesives     
+	    s = s.replaceAll("([^0-9])([\\.,])", "$1 $2 "); // tokenize period and comma unless preceded by a digit
+	    s = s.replaceAll("([\\.,])([^0-9])", " $1 $2"); // tokenize period and comma unless followed by a digit
+	    s = s.replaceAll("([0-9])(-)", "$1 $2 "); // tokenize dash when preceded by a digit
 
-	static String removePunctuation(String str) {
-		String s = str.replaceAll("[\\.,\\?:;!\"\\(\\)]", "");
-		s = s.replaceAll("\\s+", " ");
-		return s;
-	  }
+	    // further language-dependent part (if Asian support turned on):
+	    if(asianSupport) {
+		// Split Chinese chars and Japanese kanji down to character level:
+		s = s.replaceAll("([\\p{InCJKUnifiedIdeographs}\\p{InCJKUnifiedIdeographsExtensionA}])", " $1 ");
+		s = s.replaceAll("([\\p{InCJKStrokes}\\p{InCJKRadicalsSupplement}])", " $1 ");
+		s = s.replaceAll("([\\p{InCJKCompatibility}\\p{InCJKCompatibilityIdeographs}\\p{InCJKCompatibilityForms}])", " $1 ");
+		s = s.replaceAll("([\\p{InEnclosedCJKLettersAndMonths}])", " $1 ");
+
+		// Split Hiragana, Katakana, and KatakanaPhoneticExtensions
+		// only when adjacent to something else:
+		s = s.replaceAll("(^|\\P{InHiragana})(\\p{InHiragana}+)(?=$|\\P{InHiragana})", "$1 $2 ");
+		s = s.replaceAll("(^|\\P{InKatakana})(\\p{InKatakana}+)(?=$|\\P{InKatakana})", "$1 $2 ");
+		s = s.replaceAll("(^|\\P{InKatakanaPhoneticExtensions})(\\p{InKatakanaPhoneticExtensions}+)(?=$|\\P{InKatakanaPhoneticExtensions})", "$1 $2 ");
+
+		// Split punctuation:
+		s = s.replaceAll(asianPunct, " $1 ");
+		s = s.replaceAll(fullwidthPunct, " $1 ");
+	    }
+
+	    s = s.replaceAll("\\s+"," "); // one space only between words
+	    s = s.replaceAll("^\\s+", "");  // no leading space
+	    s = s.replaceAll("\\s+$", "");  // no trailing space
+	}
+	if(nopunct) s = Normalizer.removePunctuation(s, asianSupport);
+	return s.split("\\s+");
+    }
+
+    static String removePunctuation(String str, boolean asianSupport) {
+	String s = str.replaceAll("[\\.,\\?:;!\"\\(\\)]", "");
+	if(asianSupport) {
+	    s = s.replaceAll(asianPunct, "");
+	    s = s.replaceAll(fullwidthPunct, "");
+	}
+	s = s.replaceAll("\\s+", " ");
+	return s;
+    }
 
 }

--- a/src/ter/core/Shift.java
+++ b/src/ter/core/Shift.java
@@ -2,35 +2,7 @@
                                                                 
 Copyright� 2006 by BBN Technologies and University of Maryland (UMD)
 
-BBN and UMD grant a nonexclusive, source code, royalty-free right to
-use this Software known as Translation Error Rate COMpute (the
-"Software") solely for research purposes. Provided, you must agree
-to abide by the license and terms stated herein. Title to the
-Software and its documentation and all applicable copyrights, trade
-secrets, patents and other intellectual rights in it are and remain
-with BBN and UMD and shall not be used, revealed, disclosed in
-marketing or advertisement or any other activity not explicitly
-permitted in writing.
-
-BBN and UMD make no representation about suitability of this
-Software for any purposes.  It is provided "AS IS" without express
-or implied warranties including (but not limited to) all implied
-warranties of merchantability or fitness for a particular purpose.
-In no event shall BBN or UMD be liable for any special, indirect or
-consequential damages whatsoever resulting from loss of use, data or
-profits, whether in an action of contract, negligence or other
-tortuous action, arising out of or in connection with the use or
-performance of this Software.
-
-Without limitation of the foregoing, user agrees to commit no act
-which, directly or indirectly, would violate any U.S. law,
-regulation, or treaty, or any other international treaty or
-agreement to which the United States adheres or with which the
-United States complies, relating to the export or re-export of any
-commodities, software, or technical data.  This Software is licensed
-to you on the condition that upon completion you will cease to use
-the Software and, on request of BBN and UMD, will destroy copies of
-the Software in your possession.                                                
+License: LGPL v. 2.1.  See LICENSE.txt.
 
 TERshift.java v1
 Matthew Snover (snover@cs.umd.edu)                           

--- a/src/ter/core/TerScorer.java
+++ b/src/ter/core/TerScorer.java
@@ -31,6 +31,7 @@ public class TerScorer {
   private boolean normalized = false;
   private boolean caseon = false;
   private boolean nopunct = false;
+    private boolean asiansupport = false;
   private IntPair[] refSpans = null;
   private IntPair[] hypSpans = null;
   public double ref_len = -1.;
@@ -46,6 +47,10 @@ public class TerScorer {
   public void setPunct(boolean b) {
 	nopunct = b;
   }
+
+    public void setAsian(boolean b) {
+	asiansupport = b;
+    }
 
   public void setBeamWidth(int i) {
 	BEAM_WIDTH = i;
@@ -208,7 +213,7 @@ public class TerScorer {
   }
 
   public String[] tokenize(String s) {
-	  return Normalizer.tokenize(s, normalized, nopunct);
+      return Normalizer.tokenize(s, normalized, nopunct, asiansupport);
   }
     
   private Map<List<String>, Set<Integer>> BuildWordMatches(String[] hyp, 

--- a/src/ter/core/TerScorer.java
+++ b/src/ter/core/TerScorer.java
@@ -2,35 +2,7 @@
                                                                 
 Copyright� 2006 by BBN Technologies and University of Maryland (UMD)
 
-BBN and UMD grant a nonexclusive, source code, royalty-free right to
-use this Software known as Translation Error Rate COMpute (the
-"Software") solely for research purposes. Provided, you must agree
-to abide by the license and terms stated herein. Title to the
-Software and its documentation and all applicable copyrights, trade
-secrets, patents and other intellectual rights in it are and remain
-with BBN and UMD and shall not be used, revealed, disclosed in
-marketing or advertisement or any other activity not explicitly
-permitted in writing.
-
-BBN and UMD make no representation about suitability of this
-Software for any purposes.  It is provided "AS IS" without express
-or implied warranties including (but not limited to) all implied
-warranties of merchantability or fitness for a particular purpose.
-In no event shall BBN or UMD be liable for any special, indirect or
-consequential damages whatsoever resulting from loss of use, data or
-profits, whether in an action of contract, negligence or other
-tortuous action, arising out of or in connection with the use or
-performance of this Software.
-
-Without limitation of the foregoing, user agrees to commit no act
-which, directly or indirectly, would violate any U.S. law,
-regulation, or treaty, or any other international treaty or
-agreement to which the United States adheres or with which the
-United States complies, relating to the export or re-export of any
-commodities, software, or technical data.  This Software is licensed
-to you on the condition that upon completion you will cease to use
-the Software and, on request of BBN and UMD, will destroy copies of
-the Software in your possession.                                                
+License: LGPL v. 2.1.  See LICENSE.txt.
 
 TERcalc.java v1
 Matthew Snover (snover@cs.umd.edu)                           


### PR DESCRIPTION
Hi Jon,

I noticed that, though the license of Tercom was clarified to LGPL 2.1 in the Tercom LICENSE.txt file, a few of the code files had license statements in them that were conflicting and out of data.  This change just removes those statements in favor of referring to the existing LICENSE.txt.  No changes to actual TER code.

Update 2/10/17:  Here is the main meat of this pull request now: a new flag (-A) to activate support for Asian languages. Currently, the existing flags for normalization (-N) and dropping punctuation (-P) work reasonably well for languages written in the Latin alphabet, but they don't try to handle space-less languages like Chinese and Japanese.  In this updated version, if "-A" is used, then "-N" is enhanced to insert spaces in Asian-language text, and "-P" is enhanced to drop Asian punctuation.

Hope things are going well!
Greg.