### PR TITLE
New "-K" flag to remove brackets from HTML tags during normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ------------------------------------------------------------------------
-                     TRANSLATION ERROR RATE (TER) 0.9.0
+                     TRANSLATION ERROR RATE (TER) 0.10.0
 
         Matthew Snover
         Shuguang Wang
@@ -39,6 +39,7 @@ Currently, the following options are supported:
    -s case sensitivity, optional, default is insensitive
    -P no punctuations, default is with punctuations.
    -A Asian language support for -N and -P, optional, default is without.
+   -K remove brackets around HTML-style tags, optional, default is to keep
    -r reference file path, required.
    -h hypothesis file path, required.
    -o output formats, optional, default are all formats.

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project name="tercom" default="jar" basedir=".">
 
-  <property name="version" value="0.9.0" />
+  <property name="version" value="0.10.0" />
 
   <!-- Compile the Java code -->
   <target name="compile">

--- a/constants
+++ b/constants
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # These must also be updated in build.xml and README.md
-version=0.8.0
+version=0.10.0

--- a/src/ter/Parameters.java
+++ b/src/ter/Parameters.java
@@ -14,6 +14,7 @@ public class Parameters {
   private boolean case_on;
   private boolean no_punctuation;
     private boolean asian_support;
+    private boolean no_tag_brackets;
   private List<String> out_formats;
   private String out_pfx;
   private Pattern opts_p;
@@ -28,7 +29,7 @@ public class Parameters {
     private double match_cost;
 
   public static enum OPTIONS {
-      NORMALIZE, CASEON, NOPUNCTUATION, ASIANSUPPORT, REF, HYP, FORMATS, OUTPFX, BEAMWIDTH, REFLEN, TRANSSPAN, SHIFTDIST, DELETE_COST, INSERT_COST, SUBSTITUTE_COST, MATCH_COST, SHIFT_COST;
+      NORMALIZE, CASEON, NOPUNCTUATION, ASIANSUPPORT, NOTAGBRACKETS, REF, HYP, FORMATS, OUTPFX, BEAMWIDTH, REFLEN, TRANSSPAN, SHIFTDIST, DELETE_COST, INSERT_COST, SUBSTITUTE_COST, MATCH_COST, SHIFT_COST;
   }
 
   public Parameters() {
@@ -40,6 +41,7 @@ public class Parameters {
 	case_on = false;
 	no_punctuation = false;
 	asian_support = false;
+	no_tag_brackets = false;
 	opts_p = Pattern.compile("^\\s*-(\\S+)\\s*$");
 	beam_width = 20;
     span_pfx = "";
@@ -73,6 +75,9 @@ public class Parameters {
 	  case 'A':
 		    asian_support = true;
 		    break;
+	  case 'K':
+		    no_tag_brackets = true;
+		    break;		    
           case 'r':
 		    if(i == args.length -1 || args[i+1].charAt(0) == '-')
               usage();
@@ -169,6 +174,7 @@ public class Parameters {
       paras.put(OPTIONS.CASEON, case_on);
       paras.put(OPTIONS.NOPUNCTUATION, no_punctuation);
       paras.put(OPTIONS.ASIANSUPPORT, asian_support);
+      paras.put(OPTIONS.NOTAGBRACKETS, no_tag_brackets);
       paras.put(OPTIONS.OUTPFX, out_pfx);
       paras.put(OPTIONS.REF, reffn);
       paras.put(OPTIONS.HYP, hypfn);
@@ -187,7 +193,7 @@ public class Parameters {
   }
 
   public static void usage() {
-	System.out.println("** Usage: java -jar tercom.jar [-N] [-s] [-P] [-A] -r ref -h hyp [-a alter_ref] [-b beam_width] [-S trans_span_prefix] [-o out_format -n out_pefix] [-d max_shift_distance] [-M match_cost] [-D delete_cost] [-B substitute_cost] [-I insert_cost] [-T shift_cost]");
+	System.out.println("** Usage: java -jar tercom.jar [-N] [-s] [-P] [-A] [-K] -r ref -h hyp [-a alter_ref] [-b beam_width] [-S trans_span_prefix] [-o out_format -n out_pefix] [-d max_shift_distance] [-M match_cost] [-D delete_cost] [-B substitute_cost] [-I insert_cost] [-T shift_cost]");
 	System.exit(1);
   }
 

--- a/src/ter/TER.java
+++ b/src/ter/TER.java
@@ -41,6 +41,8 @@ public class TER {
 	boolean nopunct = (Boolean) val;
 	val = paras.get(Parameters.OPTIONS.ASIANSUPPORT);
 	boolean asiansupport = (Boolean) val;
+	val = paras.get(Parameters.OPTIONS.NOTAGBRACKETS);
+	boolean notagbrackets = (Boolean) val;
 	val = paras.get(Parameters.OPTIONS.OUTPFX);
 	String out_pfx;
 	if(val != null)
@@ -143,6 +145,7 @@ public class TER {
 	calc.setCase(caseon);
 	calc.setPunct(nopunct);
 	calc.setAsian(asiansupport);
+	calc.setTagBrackets(notagbrackets);
 	calc.setBeamWidth(beam_width);
 	calc.setShiftDist(shift_dist);
 

--- a/src/ter/core/Normalizer.java
+++ b/src/ter/core/Normalizer.java
@@ -5,7 +5,7 @@ public class Normalizer {
     private static String asianPunct = "([\\x{3001}\\x{3002}\\x{3008}-\\x{3011}\\x{3014}-\\x{301f}\\x{ff61}-\\x{ff65}\\x{30fb}])";
     private static String fullwidthPunct = "([\\x{ff0e}\\x{ff0c}\\x{ff1f}\\x{ff1a}\\x{ff1b}\\x{ff01}\\x{ff02}\\x{ff08}\\x{ff09}])";
 
-    public static String[] tokenize(String s, boolean normalized, boolean nopunct, boolean asianSupport) {
+    public static String[] tokenize(String s, boolean normalized, boolean nopunct, boolean asianSupport, boolean noTagBrackets) {
 
 	/* tokenizes according to the mtevalv11 specs, plus added material
 	   for handling languages written with CJK ideographs */
@@ -19,7 +19,12 @@ public class Normalizer {
 	    s = s.replaceAll("&amp;", "&"); // convert SGML tag for ampersand to &
 	    s = s.replaceAll("&lt;", "<"); // convert SGML tag for less-than to >
 	    s = s.replaceAll("&gt;", ">"); // convert SGML tag for greater-than to <
-		    
+
+	    // remove HTML-style tag brackets: "<br/>" -> "br/"
+	    if(noTagBrackets) {
+		s = s.replaceAll("<([^<>]+)>", " $1 ");
+	    }
+
 	    // language-dependent part (assuming Western languages):
 	    s = " " + s + " ";
 	    s = s.replaceAll("([\\{-\\~\\[-\\` -\\&\\(-\\+\\:-\\@\\/])", " $1 ");   // tokenize punctuation

--- a/src/ter/core/TerScorer.java
+++ b/src/ter/core/TerScorer.java
@@ -32,6 +32,7 @@ public class TerScorer {
   private boolean caseon = false;
   private boolean nopunct = false;
     private boolean asiansupport = false;
+    private boolean notagbrackets = false;
   private IntPair[] refSpans = null;
   private IntPair[] hypSpans = null;
   public double ref_len = -1.;
@@ -50,6 +51,10 @@ public class TerScorer {
 
     public void setAsian(boolean b) {
 	asiansupport = b;
+    }
+
+    public void setTagBrackets(boolean b) {
+	notagbrackets = b;
     }
 
   public void setBeamWidth(int i) {
@@ -213,7 +218,7 @@ public class TerScorer {
   }
 
   public String[] tokenize(String s) {
-      return Normalizer.tokenize(s, normalized, nopunct, asiansupport);
+      return Normalizer.tokenize(s, normalized, nopunct, asiansupport, notagbrackets);
   }
     
   private Map<List<String>, Set<Integer>> BuildWordMatches(String[] hyp, 


### PR DESCRIPTION
This change adds a new flag ("-K") to the Tercom command line to trigger dropping of bracket characters in HTML tags. By default, a tag appearing in text to be scored is broken apart into many pieces, for example "< / p >". Arguably, such a tag isn't really "worth" four words. In this Tercom change, the brackets can be removed so that the tag is only tokenized into two words: "/ p".

I'd be happy to change the new version number to 0.9.1, or whatever else you think makes sense, if you don't like 0.10.0.